### PR TITLE
Eliminate accidental duplicate terminal buffers

### DIFF
--- a/lua/betterTerm.lua
+++ b/lua/betterTerm.lua
@@ -238,6 +238,10 @@ local function smooth_new_terminal(key_term, tabpage, cmd_buf, opts)
   cmd.terminal()
   vim.bo.ft = ft
   cmd.file(key_term)
+  -- using the :file command like this creates a duplicate alternate buffer with
+  -- the buffer's old name, so we clean it up here to avoid having *two* terminals
+  -- for every *one* we wanted to create
+  cmd('bwipeout! ' .. vim.fn.expand('#'))
   term.bufid = api_funcs.buf_get_number(0)
   term.jobid = vim.b.terminal_job_id
   update_term_winbar()


### PR DESCRIPTION
I noticed that for every terminal this plugin created I was actually ending up with two terminal buffers. One with the betterTerm name, and the other with the default `term://blah` name. This removes the ones with the default name.

You can check the help entry for `:file_f*` to see that this usage creates a new unlisted buffer.