### PR TITLE
fix error caused by spaces in shell path

### DIFF
--- a/lua/betterTerm.lua
+++ b/lua/betterTerm.lua
@@ -241,10 +241,10 @@ local function smooth_new_terminal(key_term, tabpage, cmd_buf, opts)
   -- using the :file command like this creates a duplicate alternate buffer with
   -- the buffer's old name, so we clean it up here to avoid having *two* terminals
   -- for every *one* we wanted to create
-  cmd('bwipeout! ' .. vim.fn.expand('#'))
   term.bufid = api_funcs.buf_get_number(0)
   term.jobid = vim.b.terminal_job_id
   update_term_winbar()
+  cmd('bwipeout! #')
 end
 
 --- Create terminal


### PR DESCRIPTION
<img width="945" height="192" alt="image" src="https://github.com/user-attachments/assets/69e09d36-4dc6-44dd-a5f6-6b07b66f8d3e" />
The path to pwsh on Windows contained spaces, which caused a parsing error. 
I changed the parameters to use ’#‘ symbol to delete the old buffer, which did not cause the above problem.